### PR TITLE
Fix URL of the remote files and improve the code when corrupted files are downloaded

### DIFF
--- a/src/EarthOrientation.jl
+++ b/src/EarthOrientation.jl
@@ -51,14 +51,14 @@ warn_range(mjd, when) = @warn("No data available $when " *
     "$(date_from_mjd(mjd)). The last valid value will be returned.")
 
 """
-    update(;force = false)
+    update(; force=false)
 
 Download weekly EOP data from the IERS servers if newer files are available or
 no data has been downloaded previously. If the keyword `force` is `true`, then
 all the files will be downloaded again.
 """
-function update(;force = false)
-    download(data; force = force)
+function update(; force=false)
+    download(data; force=force)
     push!(EOP_DATA, paths(data, :iau1980, :iau2000)...)
     nothing
 end

--- a/src/EarthOrientation.jl
+++ b/src/EarthOrientation.jl
@@ -14,8 +14,12 @@ export getΔUT1, getΔUT1_err, getlod, getlod_err
 
 function __init__()
     if isfile(data)
-        eop = EOParams(paths(data, :iau1980, :iau2000)...)
-        push!(EOP_DATA, eop)
+        try
+            eop = EOParams(paths(data, :iau1980, :iau2000)...)
+            push!(EOP_DATA, eop)
+        catch e
+            @warn "The downloaded files seem to be corrupted. To download them again execute `EarthOrientation.update(force = true)`."
+        end
     end
 end
 

--- a/src/EarthOrientation.jl
+++ b/src/EarthOrientation.jl
@@ -25,12 +25,12 @@ end
 
 @RemoteFileSet data "IERS Data" begin
     iau1980 = @RemoteFile(
-        "https://datacenter.iers.org/eop/-/somos/5Rgv/latestXL/7/finals.all/csv",
+        "https://datacenter.iers.org/data/csv/finals.all.csv",
         file="finals.csv",
         updates=:thursdays,
     )
     iau2000 = @RemoteFile(
-        "https://datacenter.iers.org/eop/-/somos/6Rgv/latestXL/9/finals2000A.all/csv",
+        "https://datacenter.iers.org/data/csv/finals2000A.all.csv",
         file="finals2000A.csv",
         updates=:thursdays,
     )

--- a/src/EarthOrientation.jl
+++ b/src/EarthOrientation.jl
@@ -47,13 +47,14 @@ warn_range(mjd, when) = @warn("No data available $when " *
     "$(date_from_mjd(mjd)). The last valid value will be returned.")
 
 """
-    update()
+    update(;force = false)
 
 Download weekly EOP data from the IERS servers if newer files are available or
-no data has been downloaded previously.
+no data has been downloaded previously. If the keyword `force` is `true`, then
+all the files will be downloaded again.
 """
-function update()
-    download(data)
+function update(;force = false)
+    download(data; force = force)
     push!(EOP_DATA, paths(data, :iau1980, :iau2000)...)
     nothing
 end


### PR DESCRIPTION
Hi @helgee !

I was starting to see how can I use EarthOrientation.jl in SatelliteToolbox.jl, but I found two problems:

1. The URLs of the files in IERS have changed. Hence, it was not working anymore.
2. The initialization of the package was failing when a corrupted file had been downloaded.

I tried to address those problems in these 3 commits.